### PR TITLE
ansible_init

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ Build steps mostly taken from Kivy [site](https://kivy.org/doc/stable/installati
        gstreamer1.0-{omx,alsa} python-dev libmtdev-dev \
        xclip xsel
     ```
-* pip install
-  * `sudo apt install -y python-pip`
 * cython install (long time!)
   * `sudo pip install -U Cython==0.28.2`
 * kivy (long install!) - currently testing 1.10.1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ For the RasPi3B+ and 7" touchscreen, this build installs:
   * App: Etcher [for MS Windows](https://etcher.io/)
   * Burn image on to SD card
 
+## Bootstrapping
+```
+sudo apt -y install ansible
+```
+
 ## Pi Config
 You will need to connect a keyboard to the RasPi, and use the screen to follow these steps.
 * Login:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,4 @@
+Ansible playbook to perform build steps
+```
+ansible-playbook -v -i hosts -l localhost init.yaml
+```

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+hostfile = hosts

--- a/ansible/host_vars/localhost
+++ b/ansible/host_vars/localhost
@@ -1,0 +1,2 @@
+pkgs:
+  python-pip

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -1,0 +1,10 @@
+---
+- name: Initialise via Ansible
+  hosts: localhost
+  become: yes
+  tasks:
+  - name: Install packages
+    package:
+      name: "{{ item }}"
+      state: present
+    with_items: "{{ pkgs }}"


### PR DESCRIPTION
Basic Ansible playbook init.yaml to install python-pip package locally,
Remove python-pip from main build steps.
Resolves #8 