### PR TITLE
journalctl needs to be root

### DIFF
--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -82,6 +82,8 @@
       group: pi
       mode: '0644'
   - name: Ensure journalctl writes files to disk
+    become: true
+    become_user: root
     lineinfile:
       path: /etc/systemd/journald.conf
       regexp: '^Storage='


### PR DESCRIPTION
Journalctl needs to run as root in Ansible to ensure it can change the config