### PR TITLE
Fixing Ansible typo

### DIFF
--- a/ansible/init.yaml
+++ b/ansible/init.yaml
@@ -82,9 +82,7 @@
       group: pi
       mode: '0644'
   - name: Ensure journalctl writes files to disk
-    become: true
-    become_user: root
     lineinfile:
-      path: /etc/systemd/journald.conf
+      name: /etc/systemd/journald.conf
       regexp: '^Storage='
       line: Storage=persistent


### PR DESCRIPTION
Our current version of Ansible uses `name` not `path`. Stumbled over [this](https://github.com/ansible/ansible/issues/21980).